### PR TITLE
Fix verification findings: style, slugs, depersonalization

### DIFF
--- a/hardware/docs/REV3_CHANGELIST.md
+++ b/hardware/docs/REV3_CHANGELIST.md
@@ -1,7 +1,7 @@
 # Rev 3 Changelist - OpenFC-Lite
 
 Running list of changes for the next hardware revision, collected during Rev 2
-bring-up and flight testing. Stan handles all schematic/PCB edits. Items are
+bring-up and flight testing. Schematic/PCB edits are made by the maintainer. Items are
 appended as found; nothing here is implemented yet.
 
 Rev 2 bring-up context: OpenDrone-Testing bring-up logs (2026-08-05 onward).

--- a/hardware/tools/audit_design.py
+++ b/hardware/tools/audit_design.py
@@ -25,8 +25,12 @@ OUT = HW / "tools" / "design_audit.md"
 
 # ---------- Parsers ----------
 
-# kicad-skip: path setup for user-level install
-sys.path.insert(0, "/Users/stan/Library/Python/3.13/lib/python/site-packages")
+# kicad-skip: KiCad's bundled Python does not see user-level pip installs.
+# If kicad-skip lives outside the bundled interpreter's path, point the
+# KICAD_SKIP_SITE_PACKAGES environment variable at its site-packages dir.
+_extra_site = os.environ.get("KICAD_SKIP_SITE_PACKAGES")
+if _extra_site:
+    sys.path.insert(0, _extra_site)
 try:
     from skip import Schematic
 except ImportError:
@@ -213,7 +217,7 @@ def main():
         rows.append([name, f"`{path}`", "yes" if exists else "**MISSING**"])
     W(md_table(["Sheetname", "File", "On disk"], rows))
     W("")
-    W(f"Root schematic: `{ROOT_SCH.name}` — {len(sheets)} sub-sheet(s) referenced.\n")
+    W(f"Root schematic: `{ROOT_SCH.name}`, {len(sheets)} sub-sheet(s) referenced.\n")
 
     # ---- 2. Components ----
     W("## 2. Component Inventory\n")
@@ -335,12 +339,12 @@ def main():
             if loose:
                 found_net = loose[0]
         if not found_net:
-            rows.append([rail, "— (net not found)", "-", "-"])
+            rows.append([rail, "- (net not found)", "-", "-"])
             continue
         caps = find_caps_between({}, net2rp, found_net, "GND")
         # count how many pins are on this net (fanout size)
         fanout = len(net2rp.get(found_net, []))
-        rows.append([rail, found_net, len(caps), ", ".join(caps) if caps else "—"])
+        rows.append([rail, found_net, len(caps), ", ".join(caps) if caps else "-"])
     W(md_table(["Rail", "Net", "# Caps to GND", "Cap refs"], rows))
     W("")
     # Also report ALL nets that look like rails
@@ -360,7 +364,7 @@ def main():
     # Try to find the MCU's actual ADC pins: GPIO40,41,45,47 per CLAUDE.md
     mcu_ref = "U36"
     mcu_fp = fp_idx.get(mcu_ref, {})
-    # The ADC nets go to MCU pins — find them by following net back to U36
+    # The ADC nets go to MCU pins: find them by following net back to U36
     rows = []
     for role, candidates in adc_nets.items():
         net = None
@@ -370,7 +374,7 @@ def main():
                 net = sorted(match, key=len)[0]
                 break
         if not net:
-            rows.append([role, "— not found", "-", "-", "-"])
+            rows.append([role, "- not found", "-", "-", "-"])
             continue
         # Find MCU pad carrying this net
         mcu_pad = "-"
@@ -382,7 +386,7 @@ def main():
         res = [r for (r, _, _) in net2rp.get(net, []) if r.startswith("R")]
         caps = find_caps_between({}, net2rp, net, "GND")
         rows.append([role, net, mcu_pad,
-                     ", ".join(sorted(set(res))) or "—",
+                     ", ".join(sorted(set(res))) or "-",
                      ", ".join(caps) or "**NONE**"])
     W(md_table(["Role", "Net", "MCU pad", "Resistors on net", "Bypass caps to GND"], rows))
     W("")
@@ -404,14 +408,14 @@ def main():
     rows = []
     for role, nets in spi_nets.items():
         if not nets:
-            rows.append([role, "—", "-", "-"])
+            rows.append([role, "-", "-", "-"])
             continue
         net = nets[0]
         # list refs on that net
         refs = sorted(set(r for (r, _, _) in net2rp[net]))
         # resistors on net (pull-up candidates)
         rs = [r for r in refs if r.startswith("R")]
-        rows.append([role, net, ", ".join(refs), ", ".join(rs) or "—"])
+        rows.append([role, net, ", ".join(refs), ", ".join(rs) or "-"])
     W(md_table(["Signal", "Net", "Refs on net", "Resistors (pull-ups?)"], rows))
     W("")
 
@@ -441,7 +445,7 @@ def main():
     rows = []
     for role, net in cs_checks:
         if not net:
-            rows.append([role, "—", "—", "—"])
+            rows.append([role, "-", "-", "-"])
             continue
         rs = [r for (r, _, _) in net2rp.get(net, []) if r.startswith("R")]
         # Does any of those R's touch +3.3V or +3V3?
@@ -471,7 +475,7 @@ def main():
         pin_nets = ", ".join(f"{k}→{v}" for k, v in pads.items())
         # Try to identify MCU pin driving it (non-rail end)
         drivers = [v for v in pads.values() if not re.search(r"\+?(\d+V|GND|VBUS|VBAT)", v, re.I)]
-        rows.append([ref, led["value"], led["mpn"] or "-", pin_nets, ", ".join(drivers) or "—"])
+        rows.append([ref, led["value"], led["mpn"] or "-", pin_nets, ", ".join(drivers) or "-"])
     W(md_table(["Ref", "Value/Color", "MPN", "Pad nets", "Likely MCU-side net"], rows))
     W("")
     # Blue LED check
@@ -486,7 +490,7 @@ def main():
     rows = []
     for role, nets in (("I2C_SDA", sda_net), ("I2C_SCL", scl_net)):
         if not nets:
-            rows.append([role, "—", "-", "-"])
+            rows.append([role, "-", "-", "-"])
             continue
         net = nets[0]
         refs = sorted(set(r for (r, _, _) in net2rp[net]))
@@ -567,7 +571,7 @@ def main():
         if matches:
             for m in matches:
                 refs = sorted(set(r for (r, _, _) in net2rp[m]))
-                W(f"- **{pname}**: net `{m}` — refs: {', '.join(refs)}")
+                W(f"- **{pname}**: net `{m}`, refs: {', '.join(refs)}")
     # Look at U36 pad for RUN
     # Check if RUN net has a pull-up / button
     for pad, net in mcu_fp.get("pads", {}).items():
@@ -657,7 +661,7 @@ def main():
         if pad_net:
             rows.append([g, desc, pad_net[0], pad_net[1]])
         else:
-            rows.append([g, desc, "—", "— (GPIO not wired on MCU)"])
+            rows.append([g, desc, "-", "- (GPIO not wired on MCU)"])
     W(md_table(["GPIO", "CLAUDE.md function", "U36 pad", "Net"], rows))
     W("")
     # And report GPIOs on MCU NOT in the CLAUDE.md table (stragglers)
@@ -689,7 +693,7 @@ def main():
         cn = curr_candidates[0]
         caps = find_caps_between({}, net2rp, cn, "GND")
         if not caps:
-            findings.append(("HIGH", f"CURRENT-sense net `{cn}` has NO bypass cap to GND — add ~100nF near MCU ADC pin."))
+            findings.append(("HIGH", f"CURRENT-sense net `{cn}` has NO bypass cap to GND, add ~100nF near MCU ADC pin."))
     # VBAT bypass
     vb_candidates = [n for n in net2rp if re.search(r"VBAT.*SENSE|VBAT_?ADC", n, re.I)]
     if vb_candidates:
@@ -707,7 +711,7 @@ def main():
     # IMU CS pull-up (use pin function)
     imu_cs_pad_n, imu_cs_net = find_cs_pad("U14")
     if imu_cs_net and not has_pullup_to_3v3(imu_cs_net):
-        findings.append(("HIGH", f"IMU CS net `{imu_cs_net}` (U14 pad {imu_cs_pad_n}) has NO pull-up to 3.3V — "
+        findings.append(("HIGH", f"IMU CS net `{imu_cs_net}` (U14 pad {imu_cs_pad_n}) has NO pull-up to 3.3V: "
                                  "floating CS at boot can cause bus contention; add 10k to +3.3V."))
     # SD CS pull-up
     for ref, fp in fp_idx.items():
@@ -718,11 +722,11 @@ def main():
                 # Check if a resistor is on the net at all (might be pull-down or series)
                 rs = [r for (r, _, _) in net2rp.get(sd_cs_net, []) if r.startswith("R")]
                 if not rs:
-                    findings.append(("HIGH", f"SD CS net `{sd_cs_net}` has no pull-up to 3.3V — SD cards "
+                    findings.append(("HIGH", f"SD CS net `{sd_cs_net}` has no pull-up to 3.3V: SD cards "
                                              "require CS idle-high or they stay in SD-mode."))
                 else:
                     findings.append(("MED", f"SD CS net `{sd_cs_net}` has resistor(s) {rs} but none detected "
-                                            "going to 3.3V — verify pull-up vs series resistor."))
+                                            "going to 3.3V: verify pull-up vs series resistor."))
             break
     # MCU reset (RUN) pull-up
     run_net = None
@@ -731,7 +735,7 @@ def main():
             run_net = mcu_fp.get("pads", {}).get(pad, "")
             break
     if run_net and not has_pullup_to_3v3(run_net):
-        findings.append(("HIGH", f"MCU RUN net `{run_net}` has NO pull-up to 3.3V — "
+        findings.append(("HIGH", f"MCU RUN net `{run_net}` has NO pull-up to 3.3V: "
                                  "RP2350 datasheet requires external pull-up + cap on RUN."))
     # SD CS pull-up
     # LED blue

--- a/hardware/tools/design_audit.md
+++ b/hardware/tools/design_audit.md
@@ -13,7 +13,7 @@ Generated from `OpenFC.kicad_sch` + `OpenFC.kicad_pcb` via kicad-skip + pcbnew.
 | PADS | `pads.kicad_sch` | yes |
 | POWER | `power.kicad_sch` | yes |
 
-Root schematic: `OpenFC.kicad_sch` — 6 sub-sheet(s) referenced.
+Root schematic: `OpenFC.kicad_sch`, 6 sub-sheet(s) referenced.
 
 ## 2. Component Inventory
 
@@ -161,15 +161,15 @@ VBUS(USB)-+
 | Rail | Net | # Caps to GND | Cap refs |
 |---|---|---|---|
 | +BATT | +BATT | 2 | C35, C37 |
-| +12V | — (net not found) | - | - |
+| +12V | - (net not found) | - | - |
 | +5V_BUCK | +5V_BUCK | 1 | C40 |
 | +5V | +5V | 3 | C32, C33, C48 |
-| VBUS | — (net not found) | - | - |
+| VBUS | - (net not found) | - | - |
 | +3.3V | +3.3V | 17 | C1, Card2, C3, C16, C30, C31, C34, C42, C43, C44, C49, C50, C51, C52, C65, C67, C69 |
 | +1.8V_GYRO | +1.8V_GYRO | 2 | C2, C41 |
 | +1.1V | +1.1V | 4 | C27, C28, C29, C68 |
-| +1.1V_CORE | — (net not found) | - | - |
-| DVDD | — (net not found) | - | - |
+| +1.1V_CORE | - (net not found) | - | - |
+| DVDD | - (net not found) | - | - |
 
 Rail-like nets present:
 
@@ -180,9 +180,9 @@ Rail-like nets present:
 | Role | Net | MCU pad | Resistors on net | Bypass caps to GND |
 |---|---|---|---|---|
 | VBAT_SENSE | /RP2350A/ADC_VBAT | 52 | R35, R43 | C56 |
-| CURR_SENSE | /PADS/CURRENT | 49 | — | **NONE** |
-| RSSI | /PADS/RSSI | 56 | — | **NONE** |
-| EXT | — not found | - | - | - |
+| CURR_SENSE | /PADS/CURRENT | 49 | - | **NONE** |
+| RSSI | /PADS/RSSI | 56 | - | **NONE** |
+| EXT | - not found | - | - | - |
 
 **Check**: A CURRENT-sense ADC input WITHOUT a bypass cap at the MCU pin is a Betaflight MFG-guideline violation (noise couples straight into ADC).
 
@@ -190,14 +190,14 @@ Rail-like nets present:
 
 | Signal | Net | Refs on net | Resistors (pull-ups?) |
 |---|---|---|---|
-| SPI0 SCK | — | - | - |
-| SPI0 MOSI | — | - | - |
-| SPI0 MISO | — | - | - |
-| IMU CS | /IMU/GYRO_CS | U14, U36 | — |
+| SPI0 SCK | - | - | - |
+| SPI0 MOSI | - | - | - |
+| SPI0 MISO | - | - | - |
+| IMU CS | /IMU/GYRO_CS | U14, U36 | - |
 | SD CS | /BLACKBOX/BB_CS | Card2, R2, U36 | R2 |
-| SD MOSI | — | - | - |
-| SD MISO | — | - | - |
-| SD SCK | — | - | - |
+| SD MOSI | - | - | - |
+| SD MISO | - | - | - |
+| SD SCK | - | - | - |
 
 ### CS pull-up check (to +3.3V)
 
@@ -319,7 +319,7 @@ Blue LED (Betaflight LED0 requirement): **MISSING** (none)
 
 ## 13. Reset / Boot
 
-- **RUN**: net `Net-(U36-RUN)` — refs: R36, U36
+- **RUN**: net `Net-(U36-RUN)`, refs: R36, U36
 - U36 pad 35 (RUN) connects to `Net-(U36-RUN)`; refs on net: R36, U36
 
 ## 14. Connectors & Pads
@@ -414,12 +414,12 @@ Blue LED (Betaflight LED0 requirement): **MISSING** (none)
 | GPIO29 | M3 | 37 | /PADS/M3 |
 | GPIO30 | M2 | 38 | /PADS/M2 |
 | GPIO31 | M1 | 39 | /PADS/M1 |
-| GPIO32 | OSD VBLACK | — | — (GPIO not wired on MCU) |
+| GPIO32 | OSD VBLACK | - | - (GPIO not wired on MCU) |
 | GPIO33 | OSD SYNC_IN | 42 | /OSD/OSD_W |
 | GPIO34 | OSD PIXEL_SEL | 43 | /OSD/OSD_EN |
 | GPIO35 | OSD VWHITE | 44 | /OSD/OSD_SYNC |
-| GPIO36 | OSD COLOR_SEL | — | — (GPIO not wired on MCU) |
-| GPIO37 | OSD SYNCLVL | — | — (GPIO not wired on MCU) |
+| GPIO36 | OSD COLOR_SEL | - | - (GPIO not wired on MCU) |
+| GPIO37 | OSD SYNCLVL | - | - (GPIO not wired on MCU) |
 | GPIO40 | CURRENT ADC | 49 | /PADS/CURRENT |
 | GPIO41 | VBAT ADC | 52 | /RP2350A/ADC_VBAT |
 | GPIO45 | RSSI ADC | 56 | /PADS/RSSI |
@@ -444,8 +444,8 @@ GPIOs wired on MCU but not documented in CLAUDE.md:
 
 | Severity | Finding |
 |---|---|
-| HIGH | CURRENT-sense net `/PADS/CURRENT` has NO bypass cap to GND — add ~100nF near MCU ADC pin. |
+| HIGH | CURRENT-sense net `/PADS/CURRENT` has NO bypass cap to GND, add ~100nF near MCU ADC pin. |
 | LOW | RSSI ADC net `/PADS/RSSI` has no bypass cap to GND (acceptable for PWM/analog RSSI). |
-| HIGH | IMU CS net `/IMU/GYRO_CS` (U14 pad 12) has NO pull-up to 3.3V — floating CS at boot can cause bus contention; add 10k to +3.3V. |
+| HIGH | IMU CS net `/IMU/GYRO_CS` (U14 pad 12) has NO pull-up to 3.3V: floating CS at boot can cause bus contention; add 10k to +3.3V. |
 | MED | No explicit BLUE LED found for Betaflight LED0 status. |
 

--- a/hardware/tools/openfc_connectivity_report.py
+++ b/hardware/tools/openfc_connectivity_report.py
@@ -132,7 +132,7 @@ def main() -> int:
             for n in shown:
                 pinfn = f" {n['pinfunction']}" if n["pinfunction"] else ""
                 pad = f" pad {n['pad']}" if n["pad"] else ""
-                lines.append(f"- `{n['ref']}`{pad}{pinfn} — {n['value']}")
+                lines.append(f"- `{n['ref']}`{pad}{pinfn}: {n['value']}")
             if count > len(shown):
                 lines.append(f"- … {count - len(shown)} more nodes not shown")
             lines.append("")

--- a/hardware/tools/rp2350_layout_notes.md
+++ b/hardware/tools/rp2350_layout_notes.md
@@ -2,7 +2,7 @@
 
 Source: RP2350 Datasheet §6.3.8.1, Hardware Design with RP2350 guide (Raspberry Pi).
 
-## Hard constraint — buck regulator must stay on MCU side
+## Hard constraint: buck regulator must stay on MCU side
 
 Direct quote from RP2350 Datasheet §6.3.8.1:
 
@@ -37,10 +37,10 @@ Additional rules for this zone:
 | QSPI_IOVDD 100nF (pin 69) | same |
 | USB_OTP_VDD 100nF (pin 5) | same |
 | ADC_AVDD 100nF (pin 60 area) | same |
-| Crystal (12 MHz) + load caps | Risky but doable — see crystal notes |
+| Crystal (12 MHz) + load caps | Risky but doable, see crystal notes |
 | USB ESD diode + Type-C connector | OK after R7/R8 |
 
-## Crystal on bottom — caveats
+## Crystal on bottom: caveats
 
 - RP2350 uses 10.5 pF total load, ~3 pF parasitic budget
 - Each via adds 0.3-0.5 pF → 2 vias = ~1 pF budget consumed
@@ -49,7 +49,7 @@ Additional rules for this zone:
 - May need to retune R2 (1kΩ damping) or load caps (try 12pF instead of 15pF)
 - No ground flood between XIN/XOUT; maintain GND reference plane
 
-## USB — near-MCU placement
+## USB: near-MCU placement
 
 - R7/R8 (27Ω series termination): stay on **top side** immediately adjacent to pins 66/67
 - Differential pair can transition to bottom via vias AFTER the series resistors
@@ -58,7 +58,7 @@ Additional rules for this zone:
 
 ## Summary strategy for OpenFC-Lite
 
-Top side (MCU-only vision not achievable — keeps these):
+Top side (MCU-only vision not achievable, keeps these):
 - RP2354B MCU
 - Buck cluster: C_IN, L1, C_OUT, R3, C9 (~5 small parts, ~6×4 mm)
 - 2 DVDD 100nF caps closest to regulator


### PR DESCRIPTION
Fixes clean-room verification findings for OpenFC-Lite (text files only; KiCad file findings are handled in a separate pass).

## Changes

- Em dashes replaced with hyphen, comma, or colon:
  - hardware/tools/audit_design.py (18 lines: prose in comments and finding strings, table placeholder cells)
  - hardware/tools/openfc_connectivity_report.py (1 line)
  - hardware/tools/design_audit.md (21 lines, mirrors the generator changes so regeneration is stable)
  - hardware/tools/rp2350_layout_notes.md (5 lines, headings and prose)
- hardware/tools/audit_design.py: hardcoded /Users/... site-packages sys.path.insert replaced with an optional KICAD_SKIP_SITE_PACKAGES environment variable lookup
- hardware/docs/REV3_CHANGELIST.md: depersonalized maintainer reference

## Skipped (separate phase)

- En/em dashes in DOC_INPUT/DOC_RATING/DOC_TAGLINE properties inside OpenFC.kicad_pcb, OpenFC.kicad_pro, OpenFC_Panel.kicad_pcb, OpenFC_Panel.kicad_pro, _filltest.kicad_pro: KiCad file content is out of scope here.

No OpenESC_20X20 slug references exist in this repo's prose or links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)