### PR TITLE
Fix panel project filename field

### DIFF
--- a/hardware/OpenFC_Panel.kicad_pro
+++ b/hardware/OpenFC_Panel.kicad_pro
@@ -498,7 +498,7 @@
     "pinned_symbol_libs": []
   },
   "meta": {
-    "filename": "OpenFC.kicad_pro",
+    "filename": "OpenFC_Panel.kicad_pro",
     "version": 3
   },
   "net_settings": {


### PR DESCRIPTION
The panel .kicad_pro self-reference named OpenFC.kicad_pro instead of OpenFC_Panel.kicad_pro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)