### PR TITLE
chore: point every GitHub link at OpenDrone-hw

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libs/KiCad-Library"]
 	path = libs/KiCad-Library
-	url = https://github.com/incutec-hw/KiCad-Library.git
+	url = https://github.com/OpenDrone-hw/KiCad-Library.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ A pull request touching a file locked by someone else gets closed, not merged.
 ## Setup
 
 ```
-git clone --recursive https://github.com/incutec-hw/OpenFC-Lite.git
+git clone --recursive https://github.com/OpenDrone-hw/OpenFC-Lite.git
 ```
 
 KiCad 10. The `--recursive` flag pulls `libs/KiCad-Library`, which the project
@@ -41,7 +41,7 @@ kicad-cli pcb drc --exit-code-violations hardware/OpenFC.kicad_pcb
 Add new symbols, footprints and 3D models to this repo's local libraries.
 That is the working default.
 
-[incutec-hw/KiCad-Library](https://github.com/incutec-hw/KiCad-Library) is a
+[OpenDrone-hw/KiCad-Library](https://github.com/OpenDrone-hw/KiCad-Library) is a
 mirror of parts we already use or stock. Check it first: if the part is there,
 we have used it before, which saves sourcing work. Promoting a part into it is
 a separate deliberate step, not a requirement for contributing here.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenFC-Lite
 
-Open-source Betaflight flight controller built on the RP2354B, part of the incutec OpenDrone line. 6-layer PCB, 30.5 x 30.5 mm mounting pattern, 3S-6S input, microSD blackbox, PIO-driven analog OSD. Motor outputs are signal-level DShot lines to an external 4-in-1 ESC over the standard 8-pin connector; there are no onboard motor drivers, barometer, or integrated receiver. A smaller sibling, [OpenFC-Lite-Mini](https://github.com/incutec-hw/OpenFC-Lite-Mini) (20 x 20 mm, RP2354A), shares this design. Designed in KiCad 10 for JLCPCB assembly. Full design detail: [hardware/docs/DESIGN.md](hardware/docs/DESIGN.md).
+Open-source Betaflight flight controller built on the RP2354B, part of the incutec OpenDrone line. 6-layer PCB, 30.5 x 30.5 mm mounting pattern, 3S-6S input, microSD blackbox, PIO-driven analog OSD. Motor outputs are signal-level DShot lines to an external 4-in-1 ESC over the standard 8-pin connector; there are no onboard motor drivers, barometer, or integrated receiver. A smaller sibling, [OpenFC-Lite-Mini](https://github.com/OpenDrone-hw/OpenFC-Lite-Mini) (20 x 20 mm, RP2354A), shares this design. Designed in KiCad 10 for JLCPCB assembly. Full design detail: [hardware/docs/DESIGN.md](hardware/docs/DESIGN.md).
 
 <p>
 <img src="images/openfc-lite-rev2-top.png" width="400" alt="OpenFC-Lite Rev 2 top" />
@@ -66,7 +66,7 @@ Custom parts (MCU, regulators, connectors, crystal, card slot) come from the pro
 ## Build and export
 
 ```
-git clone --recursive https://github.com/incutec-hw/OpenFC-Lite.git
+git clone --recursive https://github.com/OpenDrone-hw/OpenFC-Lite.git
 ```
 
 Open `hardware/OpenFC.kicad_pro` in KiCad 10. Production exports (gerbers, BOM, CPL) are generated with the [KiCad Fabrication Toolkit](https://github.com/bennymeg/Fabrication-Toolkit) plugin. Headless checks and exports use `kicad-cli`:

--- a/hardware/docs/DESIGN.md
+++ b/hardware/docs/DESIGN.md
@@ -111,7 +111,7 @@ The Betaflight target is `OPENFC_LITE_RP2350B`. Its Rev 2 pin mapping is a rewor
 
 ## Variants
 
-The sibling [OpenFC-Lite-Mini](https://github.com/incutec-hw/OpenFC-Lite-Mini) shares this design. The two differ in MCU package, GPIO count, and some I/O; this full-size board adds bigger pads, more I/O, and OSD debug pads.
+The sibling [OpenFC-Lite-Mini](https://github.com/OpenDrone-hw/OpenFC-Lite-Mini) shares this design. The two differ in MCU package, GPIO count, and some I/O; this full-size board adds bigger pads, more I/O, and OSD debug pads.
 
 ## Revisions
 


### PR DESCRIPTION
The org was renamed `incutec-hw` → `OpenDrone-hw`. Every link here went through GitHub's rename redirect. That redirect stops working the moment `incutec-hw` is registered again, which is planned: Stan is creating a company org under that name.

Docs, README clone commands and the `.gitmodules` submodule URL. No design files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)