### PR TITLE
Raise rule floors to the line standard

### DIFF
--- a/hardware/OpenFC.kicad_pro
+++ b/hardware/OpenFC.kicad_pro
@@ -142,10 +142,10 @@
         "min_silk_clearance": 0.0,
         "min_text_height": 0.8,
         "min_text_thickness": 0.08,
-        "min_through_hole_diameter": 0.15,
+        "min_through_hole_diameter": 0.2,
         "min_track_width": 0.09,
-        "min_via_annular_width": 0.05,
-        "min_via_diameter": 0.25,
+        "min_via_annular_width": 0.075,
+        "min_via_diameter": 0.35,
         "solder_mask_to_copper_clearance": 0.005,
         "use_height_for_length_calcs": true
       },
@@ -518,7 +518,7 @@
         "schematic_color": "rgba(0, 0, 0, 0.000)",
         "track_width": 0.09,
         "tuning_profile": "",
-        "via_diameter": 0.3,
+        "via_diameter": 0.35,
         "via_drill": 0.2,
         "wire_width": 6
       }


### PR DESCRIPTION
Floors now match the line: via 0.35/0.20 drill, annular 0.075, clearance/track 0.09, edge 0.20; Default netclass via 0.35/0.2. The 214 existing 0.3/0.2 vias fail DRC on purpose until they are enlarged to 0.35: the violations are the worklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)