### PR TITLE
docs: publish the Betaflight source behind the shipped uf2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,20 @@ configurator flashes over USB. The analog OSD is rendered by a PIO program the
 target carries with it. PIO budget: PIO0 DShot, PIO1 the PIO UARTs, PIO2 LED
 strip and OSD.
 
+Betaflight is GPL-3.0, so the source matching that uf2 ships with it. Tag
+`opendrone-2026.6.0-alpha-20260806` in
+[Just4Stan/betaflight](https://github.com/Just4Stan/betaflight/tree/opendrone-2026.6.0-alpha-20260806),
+target definitions in the pinned
+[Just4Stan/config](https://github.com/Just4Stan/config/tree/opendrone-2026.6.0-alpha-20260806)
+submodule:
+
+```
+git clone --recurse-submodules=src/config \
+  -b opendrone-2026.6.0-alpha-20260806 https://github.com/Just4Stan/betaflight
+```
+
+Rebuild a uf2 with any later firmware and the tag has to move with it.
+
 ## Layout rules
 
 - The IMU's 1.8 V analog supply is deliberately separate from the 3.3 V logic

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,14 +186,14 @@ strip and OSD.
 
 Betaflight is GPL-3.0, so the source matching that uf2 ships with it. Tag
 `opendrone-2026.6.0-alpha-20260806` in
-[Just4Stan/betaflight](https://github.com/Just4Stan/betaflight/tree/opendrone-2026.6.0-alpha-20260806),
+[OpenDrone-hw/betaflight](https://github.com/OpenDrone-hw/betaflight/tree/opendrone-2026.6.0-alpha-20260806),
 target definitions in the pinned
-[Just4Stan/config](https://github.com/Just4Stan/config/tree/opendrone-2026.6.0-alpha-20260806)
+[OpenDrone-hw/betaflight-config](https://github.com/OpenDrone-hw/betaflight-config/tree/opendrone-2026.6.0-alpha-20260806)
 submodule:
 
 ```
 git clone --recurse-submodules=src/config \
-  -b opendrone-2026.6.0-alpha-20260806 https://github.com/Just4Stan/betaflight
+  -b opendrone-2026.6.0-alpha-20260806 https://github.com/OpenDrone-hw/betaflight
 ```
 
 Rebuild a uf2 with any later firmware and the tag has to move with it.


### PR DESCRIPTION
The repo distributes a uf2 built from a modified Betaflight. Betaflight is GPL-3.0, so recipients of the binary are entitled to the corresponding source.

AGENTS.md now points at tag `opendrone-2026.6.0-alpha-20260806` in OpenDrone-hw/betaflight, with the target definitions pinned in OpenDrone-hw/betaflight-config at the same tag. Both are org forks of upstream, created for this.

The committed submodule pointer on the build branch was still upstream `550ed07`, which carries neither OPENFC target, so the tag records the `6211ad4` bump that was actually built. Verified: a single `git clone --recurse-submodules=src/config -b <tag>` yields both targets.